### PR TITLE
修改了快速打开文件栏的字体颜色，让其可以正常显示（Windows） 优化调整了代码块显示边距

### DIFF
--- a/forest.css
+++ b/forest.css
@@ -676,3 +676,12 @@ table tr th:last-of-type, table tr td:last-of-type {
 #typora-source .cm-header {
   color: var(--theme-primary-color);
 }
+
+/* quick open bar */
+.typora-quick-open-item {
+  color: var(--white-color);
+  opacity: 0.3;
+}
+.typora-quick-open-item.active {
+  opacity: 1;
+}

--- a/forest.css
+++ b/forest.css
@@ -685,3 +685,8 @@ table tr th:last-of-type, table tr td:last-of-type {
 .typora-quick-open-item.active {
   opacity: 1;
 }
+
+.CodeMirror.cm-s-inner.cm-s-null-scroll.CodeMirror-wrap {
+  padding: 8px;
+}
+


### PR DESCRIPTION

![修改前](https://user-images.githubusercontent.com/76419518/226610525-b96429f8-1010-41dd-99aa-e32f43dbe06b.png)
![修改后](https://user-images.githubusercontent.com/76419518/226610538-673fa763-4616-49b4-916b-4648ffa3d3dd.png)

